### PR TITLE
updated package.json so that it gets the latest version of swagger-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commander": "^2.2.0",
     "request": "^2.60.0",
     "slugify": "^0.1.1",
-    "swagger-parser": "^2.5.0",
+    "swagger-parser": "^3.0.0",
     "inquirer": "^0.9.0",
     "q": "^1.4.1",
     "nconf": "^0.7.2"


### PR DESCRIPTION
some specifications would not be properly parsed with the previous version of swagger-parser. by changing package.json so that it looks for the latest version of swagger-parser this problem is fixed.
