### PR TITLE
fixed APIs with basePath as / when importing #17

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -52,7 +52,7 @@ var  threescale_waterfall= function(api, service_id, appplan_name,method_pattern
     for (var e in api.paths){
       for(var m in api.paths[e]){ //methods
         var method = api.paths[e][m];
-        method.path = api.basePath+e;
+        method.path = (api.basePath == "/") ? e : api.basePath+e;
         method.method = m;
         if(method_pattern){
           method.friendly_name = method_pattern.replace(/{method}/g,method.method.toUpperCase()).replace(/{path}/g,method.path);


### PR DESCRIPTION
Fix the problem on creating 3scale methods/metrics when importing swagger APIs that has the basePath as /.