### PR TITLE
Provider key is deprecated, change to access_token

### DIFF
--- a/lib/activedocs.js
+++ b/lib/activedocs.js
@@ -14,7 +14,7 @@ exports.listActiveDocs = function(){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -42,7 +42,7 @@ exports.createActiveDocs = function(file){
       method: 'POST',
       url: url,
       form:{
-        "provider_key": config.get("threescale:provider_key"),
+        "access_token": config.access_token,
         "name": api.info.title+n,
         "system_name": slug(api.info.title+n),
         "body": JSON.stringify(api),
@@ -77,7 +77,7 @@ exports.updateActiveDocs = function(file, id){
       method: 'PUT',
       url: url,
       form:{
-        "provider_key": config.get("threescale:provider_key"),
+        "access_token": config.access_token,
         "id": id,
         "body": JSON.stringify(api),
         "description": api.info.description || "Activedocs file description",
@@ -105,7 +105,7 @@ exports.deleteActiveDocs = function(activedocs_id){
     method: 'DELETE',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 

--- a/lib/application_plans.js
+++ b/lib/application_plans.js
@@ -15,7 +15,7 @@ exports.createApplicationPlan = function(service_id,name){
     method:'POST',
     url: url,
     form:{
-      "provider_key":config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "name": name || "default",
       "system_name": slug(name,"_") || "default",
       "state":"published"
@@ -41,7 +41,7 @@ exports.getApplicationPlanById = function(service_id, plan_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -65,7 +65,7 @@ exports.getApplicationPlanByName = function(service_id, plan_name){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -94,7 +94,7 @@ exports.listApplicationPlans = function(service_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -119,7 +119,7 @@ exports.deleteApplicationPlanById = function(service_id, plan_id){
     method: 'DELETE',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -143,7 +143,7 @@ exports.deleteApplicationPlanByName = function(service_id, plan_name){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,9 +17,9 @@ exports.configure = function(){
         var questions = [
           {
             type: 'input',
-            name: 'threescale_provider_key',
-            message: '3scale provider key',
-            default: nconf.get("threescale:provider_key") || 'ex: 1234567890abc',
+            name: 'threescale_access_token',
+            message: '3scale access token',
+            default: nconf.get("threescale:access_token") || 'ex: 1234567890abc',
           },
           {
             type: 'input',
@@ -30,7 +30,7 @@ exports.configure = function(){
         ];
         inquirer.prompt(questions, function(res) {
           nconf.set("threescale:id", res.threescale_id);
-          nconf.set("threescale:provider_key", res.threescale_provider_key);
+          nconf.set("threescale:access_token", res.threescale_access_token);
           nconf.save(function (err) {
             fs.readFile(osHomedir()+"/.3scale/credentials.json", function (err, data) {
               // console.dir(JSON.parse(data.toString()))
@@ -56,6 +56,6 @@ exports.get = function(key){
 };
 
 
-exports.provider_key = nconf.get("threescale:provider_key");
+exports.access_token = nconf.get("threescale:access_token");
 exports.id = nconf.get("threescale:id");
 exports.API = "https://"+nconf.get("threescale:id")+"-admin.3scale.net/admin/api";

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ var commands = require('../commands')(program);
 
 // Check if the tool is configured
 program.isConfigured = function(){
-  if(!config.get('threescale:id') || !config.get('threescale:provider_key')){
+  if(!config.get('threescale:id') || !config.get('threescale:access_token')){
     cli.error({message:"You need to configure the 3scale cli tool before using it. Configure it with the command: ", command:"3scale-cli config"});
     process.exit(1);
   }

--- a/lib/mappingrules.js
+++ b/lib/mappingrules.js
@@ -11,7 +11,7 @@ exports.createMappingRule= function(service_id, http_method, pattern, delta, met
     method: 'POST',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id": service_id,
       "http_method": http_method,
       "pattern": pattern,
@@ -40,7 +40,7 @@ exports.updateMappingRule= function(service_id, mapping_rule_id, http_method, pa
     method: 'PATCH',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id": service_id,
       "id":mapping_rule_id
     }
@@ -74,7 +74,7 @@ exports.getMappingRule= function(service_id, mapping_rule_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -98,7 +98,7 @@ exports.listMappingRules= function(service_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id": service_id,
     }
   };
@@ -122,7 +122,7 @@ exports.deleteMappingRule= function(service_id, mapping_rule_id){
     method: 'DELETE',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -12,7 +12,7 @@ exports.createMethod = function(service_id,metric_id,friendly_name, unit){
     method: 'POST',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id": service_id,
       "metric_id": metric_id,
       "friendly_name": friendly_name || "default_method",
@@ -41,7 +41,7 @@ exports.listMethods = function(service_id, metric_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -65,7 +65,7 @@ exports.getMethodById = function(service_id, metric_id, method_id){
     method: 'GET',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 
@@ -89,7 +89,7 @@ exports.updateMethod = function(service_id, metric_id, method_id, friendly_name,
     method: 'PUT',
     url: url,
     form:{
-      "provider_key": config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id": service_id,
       "metric_id": metric_id,
       "id": method_id
@@ -121,7 +121,7 @@ exports.deleteMethod = function(service_id, metric_id, method_id){
       method: 'DELETE',
       url: url,
       form:{
-        "provider_key": config.get("threescale:provider_key"),
+        "access_token": config.access_token,
       }
     };
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -12,7 +12,7 @@ exports.listMetrics = function(service_id){
     method:'GET',
     url: url,
     form:{
-      "provider_key":config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id":service_id,
     }
   };
@@ -37,7 +37,7 @@ exports.createMetric = function(service_id,friendly_name,unit){
     url: url,
     method: 'POST',
     form:{
-      "provider_key":config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id":service_id,
       "friendly_name": friendly_name,
       "unit": unit || "hit"
@@ -64,7 +64,7 @@ exports.getMetricById = function (service_id, metric_id){
     url: url,
     method: 'GET',
     form:{
-      "provider_key":config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
   var response = request(options);
@@ -88,7 +88,7 @@ exports.updateMetric = function(service_id, metric_id, friendly_name, unit){
     url: url,
     method: 'PUT',
     form:{
-      "provider_key":config.get("threescale:provider_key"),
+      "access_token": config.access_token,
       "service_id":service_id,
       "id": metric_id,
     }
@@ -119,7 +119,7 @@ exports.deleteMetric = function(service_id, metric_id){
     url: url,
     method: 'DELETE',
     form:{
-      "provider_key":config.get("threescale:provider_key")
+      "access_token": config.access_token
     }
   };
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -12,7 +12,7 @@ exports.createService = function(name){
       method:'POST',
       url: url,
       form:{
-        "provider_key": config.provider_key,
+        "access_token": config.access_token,
         "name": n, //TODO get rid of random
         "system_name": slug(n,"_")
       }
@@ -39,7 +39,7 @@ exports.listServices = function (){
     method:'GET',
     url: url,
     form:{
-      "provider_key":config.provider_key
+      "access_token": config.access_token
     }
   };
   var response = request(options);
@@ -61,7 +61,7 @@ exports.getServiceByID = function(service_id){
     method:'GET',
     url: url,
     form:{
-      "provider_key": config.provider_key,
+      "access_token": config.access_token,
       "id": service_id
     }
   };
@@ -84,7 +84,7 @@ exports.updateService = function(service_id, name){
     method:'PUT',
     url: url,
     form:{
-      "provider_key": config.provider_key,
+      "access_token": config.access_token,
       "id": service_id,
     }
   };


### PR DESCRIPTION
Provider key is not the correct way to get connected to 3scale API.
Changed to Access token.

To do: change the doc to tell how to create access token