### PR TITLE
Adding the option to allow insecure calls to the 3scale APIs. Useful …

### DIFF
--- a/commands/command-accounts.js
+++ b/commands/command-accounts.js
@@ -1,5 +1,9 @@
 var accounts = require("../lib/accounts");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
 module.exports = function accountsCommand(program) {
   program
     .command("accounts <cmd>")

--- a/commands/command-activedocs.js
+++ b/commands/command-activedocs.js
@@ -1,5 +1,10 @@
 var activedocs = require("../lib/activedocs");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function activeDocsCommand(program) {
   program
     .command("activedocs <command>")

--- a/commands/command-application_plans.js
+++ b/commands/command-application_plans.js
@@ -1,5 +1,10 @@
 var appplan = require("../lib/application_plans");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function applicationPlanCommand(program) {
   program
     .command("app-plan <cmd>")

--- a/commands/command-applications.js
+++ b/commands/command-applications.js
@@ -1,5 +1,10 @@
 var applications = require("../lib/applications");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function applicationsCommand(program) {
   program
     .command("applications <cmd>")

--- a/commands/command-config.js
+++ b/commands/command-config.js
@@ -1,6 +1,11 @@
 var services = require("../lib/services");
 var config = require("../lib/config");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function configCommand(program) {
   program
     .command("config")

--- a/commands/command-import.js
+++ b/commands/command-import.js
@@ -1,6 +1,11 @@
 var swagger = require("../lib/swagger");
 var raml = require("../lib/raml");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function importCommand(program) {
   program
      .command("import <cmd>")

--- a/commands/command-limits.js
+++ b/commands/command-limits.js
@@ -1,5 +1,10 @@
 var limits = require("../lib/limits");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function limitsCommand(program) {
   program
     .command("limits <cmd>")

--- a/commands/command-mapping_rules.js
+++ b/commands/command-mapping_rules.js
@@ -1,5 +1,10 @@
 var maprules = require("../lib/mappingrules");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function mappingRulesCommand(program) {
   program
     .command("maprules <cmd>")

--- a/commands/command-methods.js
+++ b/commands/command-methods.js
@@ -1,5 +1,10 @@
 var methods = require("../lib/methods");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function methodsRulesCommand(program) {
   program
     .command("methods <cmd>")

--- a/commands/command-metrics.js
+++ b/commands/command-metrics.js
@@ -1,5 +1,10 @@
 var metrics = require("../lib/metrics");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function metricsCommand(program) {
   program
     .command("metrics <cmd>")

--- a/commands/command-proxy.js
+++ b/commands/command-proxy.js
@@ -1,5 +1,10 @@
 var proxy = require("../lib/proxy");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function proxyCommand(program) {
   program
     .command("proxy <cmd>")

--- a/commands/command-proxy_configs.js
+++ b/commands/command-proxy_configs.js
@@ -1,5 +1,10 @@
 var proxy = require("../lib/proxy_configs");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function proxyConfigsCommand(program) {
   program
     .command("proxy-configs <cmd>")

--- a/commands/command-services.js
+++ b/commands/command-services.js
@@ -1,5 +1,10 @@
 var services = require("../lib/services");
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 module.exports = function servicesCommand(program) {
   program
     .command("services <cmd>")

--- a/lib/3scale-cli.js
+++ b/lib/3scale-cli.js
@@ -7,6 +7,11 @@ var _ = require("underscore");
 var Table = require('easy-table');
 var cli_debug = require('debug')('3scale-cli');
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.debug = function(obj){
   return require('debug')(obj.name)(obj.msg,obj.data)
 }

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -5,6 +5,11 @@ var Q = require("q");
 var request = Q.denodeify(require("request"));
 var HttpError = require('http-error-constructor');
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.listAccounts = function (){
   var url = config.API+"/accounts.json";
   var options ={

--- a/lib/activedocs.js
+++ b/lib/activedocs.js
@@ -7,6 +7,11 @@ var request = Q.denodeify(require("request"));
 
 var SwaggerParser = require('swagger-parser');
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.listActiveDocs = function(){
   var url = config.API+"/active_docs.json";
 

--- a/lib/application_plans.js
+++ b/lib/application_plans.js
@@ -8,6 +8,11 @@ var request = Q.denodeify(require("request"));
 
 var limits = require("./limits.js")
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.createApplicationPlan = function(service_id,name){
   if(!name)
     name = "default";

--- a/lib/applications.js
+++ b/lib/applications.js
@@ -5,6 +5,11 @@ var Q = require("q");
 var request = Q.denodeify(require("request"));
 var HttpError = require('http-error-constructor');
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.listApplications = function (account_id){
   var url = config.API+"/accounts/"+account_id+"/applications.json";
   var options ={

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,14 +8,16 @@ var mkdirp = require('mkdirp');
 var services = require("./services");
 var _ = require("underscore");
 
+
 nconf.file({ file: osHomedir()+"/.3scale/credentials.json" });
 nconf.load();
 
 exports.configure = function(){
-  mkdirp(osHomedir()+"/.3scale/", function (err) {  //check if ~/.3scale exists
+	
+	mkdirp(osHomedir()+"/.3scale/", function (err) {  //check if ~/.3scale exists
       if (err){ console.error(err)
       }else {
-        cli.print({message:"Please answer the following questions to configure 3scale cli."});
+        cli.print({message:"Please answer the following questions to configure 3scale cliieie."});
         var questions = [
           {
             type: 'input',
@@ -30,16 +32,23 @@ exports.configure = function(){
             default: nconf.get("threescale:id") ||  'ex: awesome-api'
           },
           {
-            type: 'input',
-            name: 'threescale_wildcard',
-            message: '3scale wildcard domain',
-            default: nconf.get("threescale:wildcard") ||  'ex: 3scale.net'
-          }
+              type: 'input',
+              name: 'threescale_wildcard',
+              message: '3scale wildcard domain',
+              default: nconf.get("threescale:wildcard") ||  'ex: 3scale.net'
+          },
+          {
+              type: 'input',
+              name: 'allowinsecure',
+              message: 'Allow Insecure Calls to 3scale API (For On Prem with Self Signed Certs)',
+              default: nconf.get("threescale:allowinsecure") ||  'Y for yes'
+            }
         ];
         inquirer.prompt(questions).then(function(res){
           nconf.set("threescale:id", res.threescale_id);
           nconf.set("threescale:access_token", res.threescale_access_token);
           nconf.set("threescale:wildcard", res.threescale_wildcard || "3scale.net");
+          nconf.set("threescale:allowinsecure", res.allowinsecure);
           nconf.save(function (err) {
             fs.readFile(osHomedir()+"/.3scale/credentials.json", function (err, data) {
               //update values
@@ -47,7 +56,13 @@ exports.configure = function(){
               exports.id = nconf.get("threescale:id");
               exports.wildcard = nconf.get("threescale:wildcard");
               exports.API = "https://"+nconf.get("threescale:id")+"-admin."+nconf.get("threescale:wildcard")+"/admin/api";
+              exports.allowinsecure = nconf.get("threescale:allowinsecure");
+              
+              if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+            	  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+              }
 
+              
               //check if configuration is valid
               testConfig(function(e, valid){
                 if(valid){
@@ -78,7 +93,7 @@ exports.get = function(key){
 var testConfig = function(callback){
   services.listServices().then(function(result){
     if(typeof result.errno != "undefined" || !_.isArray(result)){
-      cli.error({message:"ERROR encountered: Your credentials are invalid. Check them and try again."});
+      cli.error({message:"testConfig ERROR encountered: Your credentials are invalid. Check them and try again."});
       callback( new Error('Credentials invalid'));
     }else{
       callback(null, true)
@@ -90,3 +105,8 @@ exports.access_token = nconf.get("threescale:access_token");
 exports.id = nconf.get("threescale:id");
 exports.wildcard = nconf.get("threescale:wildcard");
 exports.API = "https://"+nconf.get("threescale:id")+"-admin."+nconf.get("threescale:wildcard")+"/admin/api";
+
+exports.host = "https://"+nconf.get("threescale:id")+"-admin."+nconf.get("threescale:wildcard");
+exports.basepath = "/admin/api";
+
+exports.allowinsecure = nconf.get("threescale:allowinsecure");

--- a/lib/limits.js
+++ b/lib/limits.js
@@ -5,6 +5,11 @@ var _ = require("underscore")
 var Q = require("q");
 var request = Q.denodeify(require("request"));
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.createLimit = function(plan_id, metric_id, period, value){
   var url = config.API+"/application_plans/"+plan_id+"/metrics/"+metric_id+"/limits.json";
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,11 @@ program.prompt = require('prompt');
 //include other Commands
 var commands = require('../commands')(program);
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 // Check if the tool is configured
 program.isConfigured = function(){
   if(!config.get('threescale:id') || !config.get('threescale:access_token')){

--- a/lib/mappingrules.js
+++ b/lib/mappingrules.js
@@ -4,6 +4,11 @@ var config = require("./config");
 var Q = require("q");
 var request = Q.denodeify(require("request"));
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.createMappingRule= function(service_id, http_method, pattern, delta, metric_id){
   var url = config.API+"/services/"+service_id+"/proxy/mapping_rules.json";
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -5,6 +5,11 @@ var slug = require("slug");
 var Q = require("q");
 var request = Q.denodeify(require("request"));
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.createMethod = function(service_id, metric_id, friendly_name, unit){
   var url = config.API+"/services/"+service_id+"/metrics/"+metric_id+"/methods.json";
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,6 +5,11 @@ var Q = require("q");
 var request = Q.denodeify(require("request"));
 var _ = require("underscore")
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.listMetrics = function(service_id){
   var url = config.API+"/services/"+service_id+"/metrics.json";
   // console.log(url);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,6 +4,11 @@ var config = require("./config");
 var Q = require("q");
 var request = Q.denodeify(require("request"));
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.updateProxy= function(service_id, api_backend, endpoint, sandbox_endpoint, credentials_location){
   var url = config.API+"/services/"+service_id+"/proxy.json";
 

--- a/lib/proxy_configs.js
+++ b/lib/proxy_configs.js
@@ -4,6 +4,11 @@ var config = require("./config");
 var Q = require("q");
 var request = Q.denodeify(require("request"));
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.listProxyConfigs= function(service_id, environment){
   var url = config.API+"/services/"+service_id+"/proxy/configs/"+environment+".json";
 

--- a/lib/raml.js
+++ b/lib/raml.js
@@ -19,6 +19,11 @@ var METHOD_ARR=[]
 var RESOURCESTYPES={}
 var api
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.import = function(path, service_id, appplan_name,method_pattern){
   api = parser.loadApiSync(path);
   var title = api.title()+Math.floor((Math.random() * 50) + 10);

--- a/lib/services.js
+++ b/lib/services.js
@@ -6,6 +6,11 @@ var Q = require("q");
 var request = Q.denodeify(require("request"));
 var HttpError = require('http-error-constructor');
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.createService = function(name){
     var url = config.API+"/services.json";
     var options ={

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -27,6 +27,11 @@ var ALLOWED_METHODS = [
 
 var PROMISE_DELAY = 1000 //in ms
 
+if (exports.allowinsecure == 'Y' || exports.allowinsecure == 'y'){
+  	process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
+
 exports.import = function(path, service_id, appplan_name, method_pattern, all_methods){
   cli.debug({name:'3scale-cli:swagger', msg:'Inside Swagger import function'})
   SwaggerParser.validate(path)


### PR DESCRIPTION
…for On-Prem self-signed certs.

Nico, Michal there is very likely a more elegant way to do this, i.e. if there is a common entry point to all calls, you could set the insecure mode once. But I don't know the code and I didn't see that entry point if it exists.

